### PR TITLE
fix: do not reprocess version files

### DIFF
--- a/__mocks__/@monoweave/git.ts
+++ b/__mocks__/@monoweave/git.ts
@@ -55,9 +55,31 @@ const gitResolveSha = async (
     return `sha:${ref}`
 }
 
+const gitUpstreamBranch = async ({
+    cwd,
+    context,
+}: {
+    cwd: string
+    context?: YarnContext
+}): Promise<string> => {
+    return 'main'
+}
+
 const gitDiffTree = async (
     ref: string,
-    { cwd, context }: { cwd: string; context: YarnContext },
+    {
+        cwd,
+        context,
+        onlyIncludeDeletedFiles,
+        paths,
+        fetch = false,
+    }: {
+        cwd: string
+        context?: YarnContext
+        onlyIncludeDeletedFiles?: boolean
+        paths?: string[]
+        fetch?: boolean
+    },
 ): Promise<string> => {
     return (registry.filesModified.get(ref) ?? []).join('\n')
 }
@@ -224,4 +246,5 @@ module.exports = {
     gitPushTags,
     gitResolveSha,
     gitTag,
+    gitUpstreamBranch,
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -38,6 +38,7 @@ const multiProject = {
             ...config,
             displayName: 'Unit/Integration',
             testMatch: ['<rootDir>/packages/**/*.test.ts'],
+            globalSetup: '<rootDir>/jestGlobalSetup.ts',
         },
     ],
     testTimeout: 30000,

--- a/jestGlobalSetup.ts
+++ b/jestGlobalSetup.ts
@@ -1,0 +1,9 @@
+async function setup() {
+    if (process.env.DEBUG) {
+        process.on('warning', (error) => {
+            console.error(error.message, error.stack)
+        })
+    }
+}
+
+export default setup

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -56,6 +56,7 @@
     "@monoweave/logging": "workspace:^0.0.4",
     "@monoweave/node": "workspace:^1.2.0",
     "@monoweave/types": "workspace:^1.1.0",
+    "@monoweave/versions": "workspace:*",
     "@yarnpkg/core": "^4.0.3",
     "@yarnpkg/fslib": "^3.0.2",
     "ajv": "^8.12.0",

--- a/packages/versions/src/explicit/getManualVersionStrategies.ts
+++ b/packages/versions/src/explicit/getManualVersionStrategies.ts
@@ -1,6 +1,8 @@
 import fs from 'fs'
 import path from 'path'
 
+import { gitDiffTree, gitUpstreamBranch } from '@monoweave/git'
+import logging from '@monoweave/logging'
 import {
     type DeferredVersionRecord,
     type MonoweaveConfiguration,
@@ -9,7 +11,7 @@ import {
     type YarnContext,
     isNodeError,
 } from '@monoweave/types'
-import { structUtils } from '@yarnpkg/core'
+import { hashUtils, structUtils } from '@yarnpkg/core'
 import { npath } from '@yarnpkg/fslib'
 import pLimit from 'p-limit'
 import YAML from 'yaml'
@@ -40,6 +42,32 @@ export async function parseVersionFileContents(contents: string): Promise<Deferr
     }
 }
 
+export async function writeDeferredVersionFile({
+    versionFolder,
+    deferredVersion,
+}: {
+    versionFolder: string
+    deferredVersion: DeferredVersionRecord
+}): Promise<{ versionFilePath: string }> {
+    const versionFilePath = path.resolve(
+        versionFolder,
+        `${hashUtils.makeHash(Math.random().toString()).slice(0, 8)}.md`,
+    )
+    const versionFileContents = [
+        '---',
+        ...Object.entries(deferredVersion.strategies)
+            .sort(([pkgNameA], [pkgNameB]) => pkgNameA.localeCompare(pkgNameB))
+            .map(([pkgName, strategy]) => `"${pkgName}": ${strategy}`),
+        '---',
+        deferredVersion.changelog || '',
+    ].join('\n')
+
+    await fs.promises.mkdir(path.dirname(versionFilePath), { recursive: true })
+    await fs.promises.writeFile(versionFilePath, versionFileContents, { encoding: 'utf-8' })
+
+    return { versionFilePath }
+}
+
 const allowedStrategies = new Set<string>(['patch', 'minor', 'major'])
 
 function isPackageStrategyType(raw: string): raw is PackageStrategyType {
@@ -62,22 +90,54 @@ export async function discoverVersionFiles({
         config.versionStrategy.versionFolder,
     )
 
-    try {
-        const files = await fs.promises.readdir(versionFolder, {
+    // Remove any version files which have already been consumed. i.e. check if there are deletions on the remote
+    // This is only necessary if running in an environment where we haven't pulled the latest changes on the main
+    // publish branch, e.g. GitHub's default behaviour when you don't override actions/checkout "ref" to point to the
+    // branch.
+    const filesDeletedOnUpstream = await gitUpstreamBranch({ cwd: config.cwd, context })
+        .then((upstream) =>
+            gitDiffTree(upstream, {
+                cwd: config.cwd,
+                context,
+                onlyIncludeDeletedFiles: true,
+                paths: [versionFolder],
+                fetch: true,
+            }),
+        )
+        .then((files) => files.split('\n').map((file) => path.resolve(config.cwd, file)))
+        .catch((err): string[] => {
+            logging.warning(
+                'Failed to detect deleted files on upstream. Being unable to detect deleted files ' +
+                    'means there is the possibility that monoweave may process the same version file ' +
+                    'twice, resulting in duplicate publishing.',
+                { report: context.report },
+            )
+            logging.warning(err, { report: context.report })
+            return []
+        })
+
+    const filesDeletedOnUpstreamSet = new Set<string>(filesDeletedOnUpstream)
+
+    const files = await fs.promises
+        .readdir(versionFolder, {
             encoding: 'utf-8',
             recursive: false,
             withFileTypes: true,
         })
+        .then((files) =>
+            files
+                .filter((file) => file.isFile() && file.name.endsWith('.md'))
+                .map((file) => path.resolve(versionFolder, file.path, file.name))
+                .filter((file) => !filesDeletedOnUpstreamSet.has(file)),
+        )
+        .catch((err): string[] => {
+            if (isNodeError(err) && err.code === 'ENOENT') {
+                return []
+            }
+            throw err
+        })
 
-        return files
-            .filter((file) => file.isFile() && file.name.endsWith('.md'))
-            .map((file) => path.resolve(versionFolder, file.path, file.name))
-    } catch (err) {
-        if (isNodeError(err) && err.code === 'ENOENT') {
-            return []
-        }
-        throw err
-    }
+    return files
 }
 
 export async function getManualVersionStrategies({

--- a/packages/versions/src/index.ts
+++ b/packages/versions/src/index.ts
@@ -1,5 +1,6 @@
 import applyVersionStrategies from './applyVersionStrategies'
 import getExplicitVersionStrategies from './explicit/getExplicitVersionStrategies'
+import { writeDeferredVersionFile } from './explicit/getManualVersionStrategies'
 import { getModifiedPackages } from './explicit/getModifiedPackages'
 import getImplicitVersionStrategies from './getImplicitVersionStrategies'
 import getLatestPackageTags from './getLatestPackageTags'
@@ -12,4 +13,5 @@ export {
     getExplicitVersionStrategies,
     mergeVersionStrategies,
     getModifiedPackages,
+    writeDeferredVersionFile,
 }

--- a/testUtils/misc.ts
+++ b/testUtils/misc.ts
@@ -71,7 +71,7 @@ export async function writeConfig({
 
 export async function waitFor<T>(
     predicate: () => Promise<T>,
-    { maxSteps = 100 }: { maxSteps?: number } = {},
+    { maxSteps = 200 }: { maxSteps?: number } = {},
 ): Promise<T> {
     let steps = maxSteps
     while (steps > 0) {

--- a/testUtils/misc.ts
+++ b/testUtils/misc.ts
@@ -44,7 +44,7 @@ export async function getMonoweaveConfig({
     changelogFilename: string
     dryRun: boolean
 }> &
-    RecursivePartial<MonoweaveConfiguration>): Promise<MonoweaveConfiguration> {
+    RecursivePartial<MonoweaveConfiguration> = {}): Promise<MonoweaveConfiguration> {
     return await mergeDefaultConfig({
         ...rest,
         cwd,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3068,6 +3068,7 @@ __metadata:
     "@monoweave/node": "workspace:^1.2.0"
     "@monoweave/test-utils": "link:../../testUtils"
     "@monoweave/types": "workspace:^1.1.0"
+    "@monoweave/versions": "workspace:*"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.11.24"
     "@yarnpkg/core": "npm:^4.0.3"
@@ -3436,7 +3437,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@monoweave/versions@workspace:^1.2.0, @monoweave/versions@workspace:packages/versions":
+"@monoweave/versions@workspace:*, @monoweave/versions@workspace:^1.2.0, @monoweave/versions@workspace:packages/versions":
   version: 0.0.0-use.local
   resolution: "@monoweave/versions@workspace:packages/versions"
   dependencies:


### PR DESCRIPTION
Remove any version files which have already been consumed. i.e. check if there are deletions on the remote. This is only necessary if running in an environment where we haven't pulled the latest changes on the main publish branch, e.g. GitHub's default behaviour when you don't override actions/checkout "ref" to point to the branch. This is best effort.

Closes #58 