### PR TITLE
fix: use GITHUB_REF for upstream branch in github actions

### DIFF
--- a/packages/git/src/gitCommands.ts
+++ b/packages/git/src/gitCommands.ts
@@ -20,6 +20,15 @@ export const gitUpstreamBranch = async ({
     cwd: string
     context?: YarnContext
 }): Promise<string> => {
+    if (
+        process.env.GITHUB_ACTION &&
+        process.env.GITHUB_REF &&
+        process.env.GITHUB_EVENT_NAME === 'push'
+    ) {
+        // In GitHub actions for push events, we can use GITHUB_REF.
+        return process.env.GITHUB_REF
+    }
+
     const { stdout: branch } = await git('rev-parse --abbrev-ref --symbolic-full-name @\\{u\\}', {
         cwd,
         context,

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -36,9 +36,9 @@
     "@types/node": "^20.12.2"
   },
   "dependencies": {
-    "@monoweave/changelog": "workspace:^1.2.1",
+    "@monoweave/changelog": "workspace:^1.2.0",
     "@monoweave/dependencies": "workspace:^1.1.0",
-    "@monoweave/git": "workspace:^1.2.1",
+    "@monoweave/git": "workspace:^1.2.0",
     "@monoweave/io": "workspace:^1.1.0",
     "@monoweave/logging": "workspace:^0.0.4",
     "@monoweave/publish": "workspace:^1.2.1",

--- a/packages/versions/src/explicit/getManualVersionStrategies.test.ts
+++ b/packages/versions/src/explicit/getManualVersionStrategies.test.ts
@@ -8,8 +8,6 @@ import {
     writeDeferredVersionFile,
 } from './getManualVersionStrategies'
 
-jest.mock('@monoweave/git')
-
 const mockGit = jest.mocked(git)
 
 describe('Version File Parsing', () => {
@@ -44,6 +42,12 @@ describe('Version File Parsing', () => {
 })
 
 describe('getManualVersionStrategies', () => {
+    beforeEach(() => {
+        delete process.env.GITHUB_REF
+        delete process.env.GITHUB_ACTION
+        delete process.env.GITHUB_EVENT_NAME
+    })
+
     it('returns an empty strategy map if no version files found', async () => {
         await using context = await createMonorepoContext({
             'pkg-1': {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -3031,7 +3031,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@monoweave/changelog@workspace:*, @monoweave/changelog@workspace:^1.2.1, @monoweave/changelog@workspace:packages/changelog":
+"@monoweave/changelog@workspace:*, @monoweave/changelog@workspace:^1.2.0, @monoweave/changelog@workspace:packages/changelog":
   version: 0.0.0-use.local
   resolution: "@monoweave/changelog@workspace:packages/changelog"
   dependencies:
@@ -3157,7 +3157,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@monoweave/git@workspace:*, @monoweave/git@workspace:^1.2.1, @monoweave/git@workspace:packages/git":
+"@monoweave/git@workspace:*, @monoweave/git@workspace:^1.2.0, @monoweave/git@workspace:^1.2.1, @monoweave/git@workspace:packages/git":
   version: 0.0.0-use.local
   resolution: "@monoweave/git@workspace:packages/git"
   dependencies:
@@ -3278,9 +3278,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@monoweave/node@workspace:packages/node"
   dependencies:
-    "@monoweave/changelog": "workspace:^1.2.1"
+    "@monoweave/changelog": "workspace:^1.2.0"
     "@monoweave/dependencies": "workspace:^1.1.0"
-    "@monoweave/git": "workspace:^1.2.1"
+    "@monoweave/git": "workspace:^1.2.0"
     "@monoweave/io": "workspace:^1.1.0"
     "@monoweave/logging": "workspace:^0.0.4"
     "@monoweave/publish": "workspace:^1.2.1"


### PR DESCRIPTION
To handle the edge case where a publish is not happening from the main branch but rather a push event with specific SHA checked out.