### PR TITLE
chore(ci): use local yarn cache and optimize cache keys

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -49,7 +49,12 @@ runs:
           .yarn/cache
           .yarn/unplugged
           .pnp.*
-        key: ${{ inputs.cache-prefix }}-${{ steps.detect-node.outputs.version }}-${{ hashFiles('yarn.lock') }}
+        key: ${{ inputs.cache-prefix }}-${{ hashFiles('yarn.lock') }}-${{ steps.detect-node.outputs.version }}
+        restore-keys: ${{ inputs.cache-prefix }}-
+    - name: Disable Yarn global cache
+      shell: bash
+      run: |
+        echo "YARN_ENABLE_GLOBAL_CACHE=0" >> "$GITHUB_ENV"
     - name: Install Yarn Project
       run: yarn install --immutable
       shell: bash


### PR DESCRIPTION
## Description

This PR enables creating local Yarn cache in CI which is used by `setup-env` action. Yarn by default creates global cache as described here: https://yarnpkg.com/configuration/yarnrc#enableGlobalCache

Also the cache key was modified to better optimize sharing downloaded packages between multiple node versions

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Closes #0, a short description of the linked issue.

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] I agree to abide by the [Code of Conduct](https://github.com/monoweave/monoweave/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the relevant gatsby files (documentation).
- [ ] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
