### PR TITLE
chore: remove changelog config in monoweave repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,6 @@ jobs:
           yarn run-local \
             --preset monoweave/preset-recommended \
             --log-level 0 \
-            --conventional-changelog-config @tophat/conventional-changelog-config \
             --prerelease \
             --package-group-manifest-field group
       - name: Publish via Monoweave
@@ -62,7 +61,6 @@ jobs:
           yarn run-local \
             --preset monoweave/preset-recommended \
             --log-level 0 \
-            --conventional-changelog-config @tophat/conventional-changelog-config \
             --persist-versions \
             --auto-commit-message "chore: release monoweave [skip ci]" \
             --plugins "@monoweave/plugin-github" \


### PR DESCRIPTION
In monoweave itself we'll use the builtin config