### PR TITLE
fix: manual mode improvements

### DIFF
--- a/packages/cli/src/command/version.ts
+++ b/packages/cli/src/command/version.ts
@@ -10,6 +10,43 @@ import * as t from 'typanion'
 import { BaseCommand } from './base'
 import { detectIsInCI } from './config/utils'
 
+const promptPackage = async ({
+    pkgName,
+    currentVersion,
+    defaultValue,
+}: {
+    pkgName: string
+    currentVersion: string | undefined
+    defaultValue?: string | undefined
+}): Promise<PackageStrategyType | null> => {
+    const { select } = await import('@inquirer/prompts')
+
+    const answer = await select({
+        message: `${pkgName} (current: ${currentVersion ?? 'unknown'})`,
+        default: defaultValue,
+        choices: [
+            {
+                name: 'Skip',
+                value: 'skip',
+            },
+            {
+                name: 'Patch',
+                value: 'patch',
+            },
+            {
+                name: 'Minor',
+                value: 'minor',
+            },
+            {
+                name: 'Major',
+                value: 'major',
+            },
+        ],
+    })
+
+    return answer === 'skip' ? null : (answer as PackageStrategyType)
+}
+
 export class MonoweaveVersionCommand extends BaseCommand {
     static paths = [['version']]
 
@@ -35,73 +72,44 @@ export class MonoweaveVersionCommand extends BaseCommand {
     includePatterns = Option.Rest()
 
     async execute(): Promise<number | void> {
+        if (this.interactive) {
+            this.context.stdout.write('Checking for local package modifications...\n')
+        }
+
         // inquirer has a transitive dependency on tmp which adds an event listener to process EXIT.
         // This causes the max event listeners to exceed the limit in test runs.
-        const { confirm, editor, select } = await import('@inquirer/prompts')
+        const { confirm, editor } = await import('@inquirer/prompts')
 
         let defaultStrategy: PackageStrategyType | undefined =
             this.strategy ?? (this.interactive ? undefined : 'patch')
 
         try {
             const { config } = await this.parseConfiguration()
+            const deferredVersion: DeferredVersionRecord = { changelog: '', strategies: {} }
 
-            const { remainingPackages, suggestedPackages, versionFolder } =
-                await getPackageCandidatesForManualRelease(config, {
-                    includePatterns: this.includePatterns,
-                })
+            const { packages, versionFolder } = await getPackageCandidatesForManualRelease(config, {
+                includePatterns: this.includePatterns,
+            })
 
-            if (!remainingPackages.size && !suggestedPackages.size) {
+            if (!packages.size) {
                 this.context.stdout.write('No packages detected.\n')
                 return 1
             }
 
-            const promptPackage = async ({
-                pkgName,
-                currentVersion,
-                defaultValue,
-            }: {
-                pkgName: string
-                currentVersion: string | undefined
-                defaultValue?: string | undefined
-            }): Promise<PackageStrategyType | null> => {
-                const answer = await select({
-                    message: `${pkgName} (current: ${currentVersion ?? 'unknown'})`,
-                    default: defaultValue,
-                    choices: [
-                        {
-                            name: 'Skip',
-                            value: 'skip',
-                        },
-                        {
-                            name: 'Patch',
-                            value: 'patch',
-                        },
-                        {
-                            name: 'Minor',
-                            value: 'minor',
-                        },
-                        {
-                            name: 'Major',
-                            value: 'major',
-                        },
-                    ],
-                })
-
-                return answer === 'skip' ? null : (answer as PackageStrategyType)
-            }
-
-            const deferredVersion: DeferredVersionRecord = { changelog: '', strategies: {} }
+            // The idea is that if a pattern was specified, it means the user intends to update all matched
+            // packages, even if we don't detect modification.
+            const suggestedPackages = new Map(
+                Array.from(packages.entries()).filter(
+                    ([, metadata]) => metadata.modified || Boolean(this.includePatterns.length),
+                ),
+            )
 
             if (suggestedPackages.size) {
-                if (this.interactive) {
-                    this.context.stdout.write(
-                        `${suggestedPackages.size} package${suggestedPackages.size === 1 ? '' : 's'} modified. Select the version strategies to apply:\n`,
-                    )
-                } else {
-                    this.context.stdout.write(
-                        `${suggestedPackages.size} package${suggestedPackages.size === 1 ? '' : 's'} selected.\n`,
-                    )
-                }
+                this.context.stdout.write(
+                    `${suggestedPackages.size} package${suggestedPackages.size === 1 ? '' : 's'} ${this.includePatterns.length ? 'selected' : 'modified'}. ${
+                        this.interactive ? 'Select the version strategies to apply:' : ''
+                    }\n`,
+                )
 
                 for (const [pkgName, { currentVersion }] of suggestedPackages.entries()) {
                     const strategy = this.interactive
@@ -118,11 +126,17 @@ export class MonoweaveVersionCommand extends BaseCommand {
                 }
             }
 
+            const remainingPackages = new Map(
+                Array.from(packages.entries()).filter(([name]) => !suggestedPackages.has(name)),
+            )
+
             if (
                 this.interactive &&
                 remainingPackages.size &&
                 (await confirm({
-                    message: `There ${remainingPackages.size === 1 ? 'is' : 'are'} ${remainingPackages.size} unmodified package${remainingPackages.size === 1 ? '' : 's'}. Would you like to review ${remainingPackages.size === 1 ? 'it' : 'them'}?\n`,
+                    message:
+                        `There ${remainingPackages.size === 1 ? 'is' : 'are'} ${remainingPackages.size} unmodified package${remainingPackages.size === 1 ? '' : 's'}. ` +
+                        `Would you like to review ${remainingPackages.size === 1 ? 'it' : 'them'}?\n`,
                     default: false,
                 }))
             ) {
@@ -165,7 +179,8 @@ export class MonoweaveVersionCommand extends BaseCommand {
 
             if (this.interactive) {
                 this.context.stdout.write(
-                    `A version file has been written to: ${path.relative(process.cwd(), versionFilePath)}. You can modify the version file before committing it.\n`,
+                    `A version file has been written to: ${path.relative(process.cwd(), versionFilePath)}. ` +
+                        'You can modify the version file before committing it.\n',
                 )
             } else {
                 this.context.stdout.write(
@@ -181,7 +196,7 @@ export class MonoweaveVersionCommand extends BaseCommand {
             }
 
             this.context.stderr.write(`${err}\n`)
-            if (process.env.DEBUG === 'monoweave') {
+            if (process.env.DEBUG?.match(/monoweave|(^\*$)/)) {
                 if (err instanceof Error) {
                     this.context.stderr.write(`${err.stack}\n`)
                 }

--- a/packages/cli/src/version.test.ts
+++ b/packages/cli/src/version.test.ts
@@ -49,8 +49,7 @@ describe('CLI - Version', () => {
         await using temp = await createTempDir()
 
         jestImport.spyOn(monoweave, 'getPackageCandidatesForManualRelease').mockResolvedValue({
-            remainingPackages: new Map([]),
-            suggestedPackages: new Map([]),
+            packages: new Map([]),
             versionFolder: temp.dir,
         })
 
@@ -76,10 +75,9 @@ describe('CLI - Version', () => {
             await using temp = await createTempDir()
 
             jestImport.spyOn(monoweave, 'getPackageCandidatesForManualRelease').mockResolvedValue({
-                remainingPackages: new Map([]),
-                suggestedPackages: new Map([
-                    ['pkg-1', { currentVersion: '1.0.0' }],
-                    ['pkg-2', { currentVersion: '1.0.0' }],
+                packages: new Map([
+                    ['pkg-1', { currentVersion: '1.0.0', modified: true }],
+                    ['pkg-2', { currentVersion: '1.0.0', modified: true }],
                 ]),
                 versionFolder: temp.dir,
             })
@@ -115,10 +113,9 @@ describe('CLI - Version', () => {
             await using temp = await createTempDir()
 
             jestImport.spyOn(monoweave, 'getPackageCandidatesForManualRelease').mockResolvedValue({
-                remainingPackages: new Map([]),
-                suggestedPackages: new Map([
-                    ['pkg-1', { currentVersion: '1.0.0' }],
-                    ['pkg-2', { currentVersion: '1.0.0' }],
+                packages: new Map([
+                    ['pkg-1', { currentVersion: '1.0.0', modified: true }],
+                    ['pkg-2', { currentVersion: '1.0.0', modified: true }],
                 ]),
                 versionFolder: temp.dir,
             })

--- a/packages/node/src/tests/version.test.ts
+++ b/packages/node/src/tests/version.test.ts
@@ -112,31 +112,34 @@ describe('Monoweave - Manual Mode', () => {
     it('suggests modified packages since last tag', async () => {
         mockGit._commitFiles_('sha1', 'feat: some new feature!', ['./packages/pkg-1/README.md'])
 
-        const { remainingPackages, suggestedPackages } =
-            await getPackageCandidatesForManualRelease(monoweaveConfig)
-        expect(Array.from(suggestedPackages.keys())).toEqual(['pkg-1'])
-        expect(Array.from(remainingPackages.keys())).toEqual(['pkg-2', 'pkg-3'])
+        const { packages } = await getPackageCandidatesForManualRelease(monoweaveConfig)
+
+        expect(packages.size).toBe(3)
+        expect(packages.get('pkg-1')).toEqual(expect.objectContaining({ modified: true }))
+        expect(packages.get('pkg-2')).toEqual(expect.objectContaining({ modified: false }))
+        expect(packages.get('pkg-3')).toEqual(expect.objectContaining({ modified: false }))
     })
 
     it('filters packages using glob patterns', async () => {
         mockGit._commitFiles_('sha1', 'feat: some new feature!', ['./packages/pkg-1/README.md'])
 
-        const { remainingPackages, suggestedPackages } = await getPackageCandidatesForManualRelease(
-            monoweaveConfig,
-            { includePatterns: ['*-2', 'package-*'] },
-        )
-        expect(Array.from(suggestedPackages.keys())).toEqual([])
-        expect(Array.from(remainingPackages.keys())).toEqual(['pkg-2'])
+        const { packages } = await getPackageCandidatesForManualRelease(monoweaveConfig, {
+            includePatterns: ['*-2', 'package-*'],
+        })
+        expect(packages.size).toBe(1)
+        expect(packages.get('pkg-2')).toEqual(expect.objectContaining({ modified: false }))
     })
 
     it('does not filter if includePatterns is empty', async () => {
         mockGit._commitFiles_('sha1', 'feat: some new feature!', ['./packages/pkg-1/README.md'])
 
-        const { remainingPackages, suggestedPackages } = await getPackageCandidatesForManualRelease(
-            monoweaveConfig,
-            { includePatterns: [] },
-        )
-        expect(Array.from(suggestedPackages.keys())).toEqual(['pkg-1'])
-        expect(Array.from(remainingPackages.keys())).toEqual(['pkg-2', 'pkg-3'])
+        const { packages } = await getPackageCandidatesForManualRelease(monoweaveConfig, {
+            includePatterns: [],
+        })
+
+        expect(packages.size).toBe(3)
+        expect(packages.get('pkg-1')).toEqual(expect.objectContaining({ modified: true }))
+        expect(packages.get('pkg-2')).toEqual(expect.objectContaining({ modified: false }))
+        expect(packages.get('pkg-3')).toEqual(expect.objectContaining({ modified: false }))
     })
 })


### PR DESCRIPTION
Do not prompt for confirmation when using a filter with monoweave, closes #145. Add a message to indicate work is being done at start of command, closes #123.


