### PR TITLE
fix: support running monoweave from subdirectory

### DIFF
--- a/e2e-tests/helpers/docker.ts
+++ b/e2e-tests/helpers/docker.ts
@@ -21,7 +21,7 @@ const isUp = (): Promise<void> =>
         }
     })
 
-export async function waitForRegistry(timeout = 20000): Promise<boolean> {
+async function waitForRegistry(timeout = 20000): Promise<boolean> {
     console.log('Waiting for registry to start up...')
 
     const DELAY = 1000
@@ -42,7 +42,21 @@ export async function stopRegistry(): Promise<void> {
     if (stderr) console.error(stderr)
 }
 
-export async function startRegistry(): Promise<void> {
+export async function startRegistry(): Promise<AsyncDisposable> {
+    try {
+        await stopRegistry()
+    } catch {}
+
     const { stderr } = await exec('yarn workspace @monoweave/e2e-tests test:registry:start')
     if (stderr) console.error(stderr)
+
+    await waitForRegistry(25000)
+
+    return {
+        async [Symbol.asyncDispose]() {
+            try {
+                await stopRegistry()
+            } catch {}
+        },
+    }
 }

--- a/e2e-tests/helpers/runner.ts
+++ b/e2e-tests/helpers/runner.ts
@@ -36,12 +36,16 @@ export default async function run({ cwd, args = '' }: { cwd: string; args: strin
             },
         )
         if (process.env.DEBUG?.includes('test:e2e')) {
-            if (stdout) console.log(stdout)
+            if (stdout) console.error(stdout)
             if (stderr) console.error(stderr)
         }
         return { stdout, stderr }
     } catch (err) {
         if (isNodeError<ExecException>(err)) {
+            if (process.env.DEBUG?.includes('test:e2e')) {
+                if (err.stdout) console.error(err.stdout)
+                if (err.stderr) console.error(err.stderr)
+            }
             return { error: err, stdout: err?.stdout, stderr: err?.stderr }
         }
         throw new Error('Unexpected error')

--- a/e2e-tests/helpers/setupProject.ts
+++ b/e2e-tests/helpers/setupProject.ts
@@ -14,7 +14,7 @@ import {
 import { type MonoweaveConfiguration, type RecursivePartial } from '@monoweave/types'
 import { npath } from '@yarnpkg/fslib'
 
-import { startRegistry, stopRegistry, waitForRegistry } from './docker'
+import { startRegistry, stopRegistry } from './docker'
 import run from './runner'
 
 const registryUrl = 'http://localhost:4873'
@@ -30,102 +30,112 @@ type ExecFn = (cmd: string) => ReturnType<typeof exec>
 type ReadFile = (filepath: string) => Promise<string>
 type WriteFile = (filepath: string, data: string | Record<string, unknown>) => Promise<string>
 
-type TestCase = (params: {
+interface TestContext {
     cwd: string
     run: RunFn
     readFile: ReadFile
     writeFile: WriteFile
     exec: ExecFn
-}) => Promise<void>
+}
 
-export default function setupProject({
+export async function writeConfigWithLocalRegistry(
+    config: RecursivePartial<MonoweaveConfiguration>,
+    { cwd }: { cwd: string },
+): Promise<string> {
+    return path.relative(
+        cwd,
+        await writeConfig({
+            cwd,
+            config: {
+                registryUrl,
+                ...config,
+            },
+        }),
+    )
+}
+
+export function createSetupProjectContext({
+    configFilename,
+    project,
+}: {
+    configFilename: string
+    project: string
+}) {
+    return {
+        cwd: project,
+        run: (args?: string[]) => {
+            if (!project) throw new Error('Missing project path.')
+            console.log(`Temporary Project: ${project}`)
+
+            return run({
+                cwd: project,
+                args: [`--config-file ${configFilename}`, ...(args ? args : [])].join(' '),
+            })
+        },
+        readFile: (filename: string) => {
+            if (!project) throw new Error('Missing project path.')
+            return fs.readFile(path.resolve(project, filename), {
+                encoding: 'utf8',
+            })
+        },
+        writeFile: async (
+            filename: string,
+            data: string | Record<string, unknown>,
+        ): Promise<string> => {
+            if (!project) throw new Error('Missing project path.')
+            const fullFilename = path.resolve(project, filename)
+            await fs.appendFile(
+                fullFilename,
+                typeof data === 'string' ? data : JSON.stringify(data, null, 4),
+                'utf-8',
+            )
+            return fullFilename
+        },
+        exec: (command: string) => {
+            if (!project) throw new Error('Missing project path.')
+            return exec(command, { cwd: project })
+        },
+    }
+}
+
+export default async function setupProject({
     repository,
     config,
-    testCase,
 }: {
     repository: Parameters<typeof setupTestRepository>
     config: RecursivePartial<MonoweaveConfiguration>
-    testCase: TestCase
-}): () => Promise<void> {
-    return async (): Promise<void> => {
-        try {
-            await stopRegistry()
-        } catch {}
-        await startRegistry()
-        await waitForRegistry(25000)
+}): Promise<TestContext & AsyncDisposable> {
+    await startRegistry()
 
-        let project: string | null = null
-        let remotePath: string | null = null
+    let project: string | null = null
+    let remotePath: string | null = null
 
-        try {
-            // the project we're publishing
-            project = await setupTestRepository(...repository)
+    // the project we're publishing
+    project = await setupTestRepository(...repository)
 
-            // remote to push tags/artifacts to
-            remotePath = await fs.mkdtemp(path.join(os.tmpdir(), 'monorepo-'))
-            await initGitRepository(npath.toPortablePath(remotePath))
-            await addGitRemote(project, remotePath, 'origin')
+    // remote to push tags/artifacts to
+    remotePath = await fs.mkdtemp(path.join(os.tmpdir(), 'monorepo-'))
+    await initGitRepository(npath.toPortablePath(remotePath))
+    await addGitRemote(project, remotePath, 'origin')
 
-            const configFilename = path.relative(
-                project,
-                await writeConfig({
-                    cwd: project,
-                    config: {
-                        registryUrl,
-                        ...config,
-                    },
-                }),
-            )
+    const configFilename = await writeConfigWithLocalRegistry(config, { cwd: project })
 
-            // initial commit
-            await exec('git pull --rebase --no-verify origin main', {
-                cwd: project,
-            })
-            await exec('git add . && git commit -n -m "initial commit"', {
-                cwd: project,
-            })
-            await exec('git push -u origin main', {
-                cwd: project,
-            })
+    // initial commit
+    await exec('git pull --rebase --no-verify origin main', {
+        cwd: project,
+    })
+    await exec('git add . && git commit -n -m "initial commit"', {
+        cwd: project,
+    })
+    await exec('git push -u origin main', {
+        cwd: project,
+    })
 
-            await testCase({
-                cwd: project,
-                run: (args?: string[]) => {
-                    if (!project) throw new Error('Missing project path.')
-                    console.log(`Temporary Project: ${project}`)
-
-                    return run({
-                        cwd: project,
-                        args: [`--config-file ${configFilename}`, ...(args ? args : [])].join(' '),
-                    })
-                },
-                readFile: (filename: string) => {
-                    if (!project) throw new Error('Missing project path.')
-                    return fs.readFile(path.resolve(project, filename), {
-                        encoding: 'utf8',
-                    })
-                },
-                writeFile: async (
-                    filename: string,
-                    data: string | Record<string, unknown>,
-                ): Promise<string> => {
-                    if (!project) throw new Error('Missing project path.')
-                    const fullFilename = path.resolve(project, filename)
-                    await fs.appendFile(
-                        fullFilename,
-                        typeof data === 'string' ? data : JSON.stringify(data, null, 4),
-                        'utf-8',
-                    )
-                    return fullFilename
-                },
-                exec: (command: string) => {
-                    if (!project) throw new Error('Missing project path.')
-                    return exec(command, { cwd: project })
-                },
-            })
-        } finally {
+    return {
+        ...createSetupProjectContext({ project, configFilename }),
+        async [Symbol.asyncDispose]() {
             await cleanUp([project, remotePath].filter((v): v is string => v !== null))
             await stopRegistry()
-        }
+        },
     }
 }

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -7,9 +7,10 @@
         "test:registry:start": "docker run -itd -p 4873:4873 --name monoweave-registry monoweave-test-registry",
         "test:registry:stop": "docker stop monoweave-registry && docker container rm monoweave-registry",
         "test:registry": "run test:registry:build && run test:registry:start",
-        "bin:test": "run workspace:test --runInBand --maxConcurrency=1 --verbose --testTimeout=300000",
-        "test": "run bin:test --selectProjects E2E -- $(pwd)",
-        "test:watch": "run bin:test --watch --selectProjects E2E --"
+        "bin:test": "E2E=1 run workspace:test --runInBand --maxConcurrency=1 --verbose --testTimeout=300000",
+        "bin:test:debug": "E2E=1 run bin:jest:debug --runInBand --maxConcurrency=1 --verbose --testTimeout=60000000",
+        "test": "E2E=1 run bin:test --selectProjects E2E -- $(pwd)",
+        "test:watch": "E2E=1 run bin:test --watch --selectProjects E2E --"
     },
     "devDependencies": {
         "@jest/globals": "^30.0.0-alpha.6",

--- a/e2e-tests/tests/issues/issue-165.test.ts
+++ b/e2e-tests/tests/issues/issue-165.test.ts
@@ -1,0 +1,148 @@
+import path from 'node:path'
+
+import { describe, expect, it } from '@jest/globals'
+import { exec } from '@monoweave/io'
+import {
+    addGitRemote,
+    createFile,
+    createMonorepoContext,
+    createTempDir,
+    initGitRepository,
+} from '@monoweave/test-utils'
+import { RegistryMode } from '@monoweave/types'
+import { npath } from '@yarnpkg/fslib'
+
+import { startRegistry } from 'helpers/docker'
+import { createSetupProjectContext, writeConfigWithLocalRegistry } from 'helpers/setupProject'
+
+// https://github.com/monoweave/monoweave/issues/165
+describe('Issue #165', () => {
+    it('supports yarn monorepos not anchored at the root of the git repository', async () => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        await using _ = await startRegistry()
+
+        await using gitRoot = await createTempDir()
+        await using remoteGitDir = await createTempDir()
+
+        // Init git and remote
+        await initGitRepository(npath.toPortablePath(gitRoot.dir))
+        await initGitRepository(npath.toPortablePath(remoteGitDir.dir))
+        await addGitRemote(gitRoot.dir, remoteGitDir.dir, 'origin')
+
+        // Create the top-level yarn project at a subdirectory rather than at the root
+        // of the git project
+        const yarnSubdir = path.join(gitRoot.dir, 'yarn-project')
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        await using __ = await createMonorepoContext(
+            {
+                'pkg-1': {},
+            },
+            { cwd: yarnSubdir },
+        )
+        const configFilename = await writeConfigWithLocalRegistry(
+            {
+                access: 'public',
+                changelogFilename: 'CHANGELOG.md',
+                dryRun: false,
+                autoCommit: true,
+                autoCommitMessage: 'chore: release',
+                conventionalChangelogConfig: require.resolve(
+                    '@tophat/conventional-changelog-config',
+                ),
+                git: {
+                    push: true,
+                    remote: 'origin',
+                    tag: true,
+                },
+                jobs: 1,
+                persistVersions: false,
+                registryMode: RegistryMode.NPM,
+                topological: true,
+                topologicalDev: true,
+                maxConcurrentReads: 1,
+                maxConcurrentWrites: 1,
+            },
+            { cwd: yarnSubdir },
+        )
+
+        // Create the non-yarn subfolder. The purpose of this test is to ensure modifications to the
+        // non-yarn subfolder are NOT picked up by monoweave.
+        const otherSubdir = path.join(gitRoot.dir, 'other-project')
+
+        // Create 2 files with the same names across both subdirectories
+        const commonFilename = 'example.txt'
+        const exampleFileOther = await createFile({
+            filePath: commonFilename,
+            content: 'Contents...',
+            cwd: otherSubdir,
+        })
+        const exampleFileYarn = await createFile({
+            filePath: commonFilename,
+            content: 'Contents...',
+            cwd: yarnSubdir,
+        })
+
+        // Initial git commit
+        await exec('git pull --rebase --no-verify origin main', {
+            cwd: gitRoot.dir,
+        })
+        await exec('git add . && git commit -n -m "initial commit"', {
+            cwd: gitRoot.dir,
+        })
+        await exec('git push -u origin main', {
+            cwd: gitRoot.dir,
+        })
+
+        const ctx = createSetupProjectContext({
+            project: yarnSubdir,
+            configFilename,
+        })
+
+        // Modify the example.txt file in the non-Yarn project. If everything is working correctly,
+        // monoweave should NOT detect this change as it's outside the scope of the Yarn project.
+        await ctx.writeFile(exampleFileOther, 'other modification')
+        await ctx.exec('git add --all && git commit -n -m "feat: other" && git push')
+
+        let { stdout: beforeRunCommitSHA } = await ctx.exec('git rev-parse HEAD')
+
+        // Trigger monoweave. There should be NO modifications.
+        let { error } = await ctx.run()
+        if (error) console.error(error)
+        expect(error).toBeUndefined()
+
+        const { stdout: afterRunCommitSHA } = await ctx.exec('git rev-parse HEAD')
+
+        // Monoweave should not have created a commit at all.
+        expect(beforeRunCommitSHA.trim()).toBe(afterRunCommitSHA.trim())
+
+        // Changelog should also not exist anywhere.
+        await expect(ctx.readFile(path.join('..', 'CHANGELOG.md'))).rejects.toThrow()
+        await expect(ctx.readFile(path.join(yarnSubdir, 'CHANGELOG.md'))).rejects.toThrow()
+        await expect(ctx.readFile(path.join(otherSubdir, 'CHANGELOG.md'))).rejects.toThrow()
+
+        // There should be no git tags
+        await expect(exec('git describe', { cwd: gitRoot.dir })).rejects.toThrow()
+
+        // Modify the example.txt in the Yarn project. Monoweave SHOULD detect this change.
+        await ctx.writeFile(exampleFileYarn, 'yarn modification')
+        await ctx.exec('git add --all && git commit -n -m "feat: yarn 123" && git push')
+
+        beforeRunCommitSHA = (await ctx.exec('git rev-parse HEAD')).stdout
+
+        // Trigger monoweave. We expect a modification to the yarn subfolder
+        error = (await ctx.run()).error
+        if (error) console.error(error)
+        expect(error).toBeUndefined()
+
+        // Expect a new commit
+        expect(beforeRunCommitSHA.trim()).not.toBe(afterRunCommitSHA.trim())
+
+        // Changelog should be updated.
+        await expect(ctx.readFile(path.join(yarnSubdir, 'CHANGELOG.md'))).resolves.toContain(
+            'yarn 123',
+        )
+
+        // And sanity check: there should be no changelog file at the root of the git project
+        await expect(ctx.readFile(path.join('..', 'CHANGELOG.md'))).rejects.toThrow()
+    })
+})

--- a/e2e-tests/tests/issues/issue-95.test.ts
+++ b/e2e-tests/tests/issues/issue-95.test.ts
@@ -5,9 +5,8 @@ import setupProject from 'helpers/setupProject'
 
 // https://github.com/monoweave/monoweave/issues/95
 describe('Issue #95', () => {
-    it(
-        'handles merge conflicts',
-        setupProject({
+    it('handles merge conflicts', async () => {
+        await using testContext = await setupProject({
             repository: [
                 {
                     'pkg-1': {},
@@ -35,72 +34,70 @@ describe('Issue #95', () => {
                 maxConcurrentReads: 1,
                 maxConcurrentWrites: 1,
             },
-            testCase: async ({ run, readFile, exec, writeFile }) => {
-                // First semantic commit
-                await writeFile('packages/pkg-1/README.md', 'Modification.')
-                await exec('git add . && git commit -n -m "feat: change 1" && git push')
+        })
 
-                const { error } = await run()
-                if (error) console.error(error)
-                expect(error).toBeUndefined()
+        const { run, readFile, exec, writeFile } = testContext
+        // First semantic commit
+        await writeFile('packages/pkg-1/README.md', 'Modification.')
+        await exec('git add . && git commit -n -m "feat: change 1" && git push')
 
-                // We should have a 'pkg-1/CHANGELOG.md' at this point.
-                expect(await readFile('packages/pkg-1/CHANGELOG.md')).toMatch(/change 1/)
+        const { error } = await run()
+        if (error) console.error(error)
+        expect(error).toBeUndefined()
 
-                await exec('git checkout -b change_2')
-                await writeFile('packages/pkg-1/README.md', 'Modification 2.')
-                await exec('git add . && git commit -n -m "feat: change 2"')
+        // We should have a 'pkg-1/CHANGELOG.md' at this point.
+        expect(await readFile('packages/pkg-1/CHANGELOG.md')).toMatch(/change 1/)
 
-                await exec('git checkout -b change_3') // change_3 is based on change_2
-                await writeFile('packages/pkg-1/README.md', 'Modification 3.')
-                await exec('git add . && git commit -n -m "feat: change 3"')
+        await exec('git checkout -b change_2')
+        await writeFile('packages/pkg-1/README.md', 'Modification 2.')
+        await exec('git add . && git commit -n -m "feat: change 2"')
 
-                // Back on change 2, we'll publish
-                await exec('git checkout main')
-                await exec('git merge change_2 --no-verify --no-edit')
+        await exec('git checkout -b change_3') // change_3 is based on change_2
+        await writeFile('packages/pkg-1/README.md', 'Modification 3.')
+        await exec('git add . && git commit -n -m "feat: change 3"')
 
-                const { error: error2 } = await run()
-                if (error2) console.error(error2)
-                expect(error2).toBeUndefined()
+        // Back on change 2, we'll publish
+        await exec('git checkout main')
+        await exec('git merge change_2 --no-verify --no-edit')
 
-                // At this point we expected change 2 followed by change 1 in the changelog
-                let remoteChangelog = (
-                    await exec('git cat-file blob origin/main:packages/pkg-1/CHANGELOG.md')
-                ).stdout
-                expect(remoteChangelog).toMatch(/change 2.*change 1/s)
+        const { error: error2 } = await run()
+        if (error2) console.error(error2)
+        expect(error2).toBeUndefined()
 
-                // Switch back to change_3 which is now "out of sync" with main
-                await exec('git checkout main')
-                await exec('git reset --hard change_3')
+        // At this point we expected change 2 followed by change 1 in the changelog
+        let remoteChangelog = (
+            await exec('git cat-file blob origin/main:packages/pkg-1/CHANGELOG.md')
+        ).stdout
+        expect(remoteChangelog).toMatch(/change 2.*change 1/s)
 
-                // If we attempt to publish, we'll have a conflict with the CHANGELOG.md file
-                // since our change_3 will only have change 1 and change 3 and will be missing change 2.
-                // We'll validate this:
-                remoteChangelog = (
-                    await exec('git cat-file blob origin/main:packages/pkg-1/CHANGELOG.md')
-                ).stdout
-                expect(remoteChangelog).toEqual(expect.stringContaining('change 1'))
-                expect(remoteChangelog).toEqual(expect.stringContaining('change 2'))
-                expect(remoteChangelog).not.toEqual(expect.stringContaining('change 3'))
+        // Switch back to change_3 which is now "out of sync" with main
+        await exec('git checkout main')
+        await exec('git reset --hard change_3')
 
-                // Now we publish. It's up to monoweave to deal with or prevent conflicts.
-                const { error: error3 } = await run()
-                if (error3) console.error(error3)
-                expect(error3).toBeUndefined()
+        // If we attempt to publish, we'll have a conflict with the CHANGELOG.md file
+        // since our change_3 will only have change 1 and change 3 and will be missing change 2.
+        // We'll validate this:
+        remoteChangelog = (await exec('git cat-file blob origin/main:packages/pkg-1/CHANGELOG.md'))
+            .stdout
+        expect(remoteChangelog).toEqual(expect.stringContaining('change 1'))
+        expect(remoteChangelog).toEqual(expect.stringContaining('change 2'))
+        expect(remoteChangelog).not.toEqual(expect.stringContaining('change 3'))
 
-                // If we get this far, monoweave didn't fail due to the conflicts. We'll verify the changelog
-                // with ordering:
-                remoteChangelog = (
-                    await exec('git cat-file blob origin/main:packages/pkg-1/CHANGELOG.md')
-                ).stdout
-                expect(remoteChangelog).toMatch(/change 3.*change 2.*change 1/s)
-                await exec('git checkout --force change_3')
-                expect((await exec('git describe --abbrev=0')).stdout.trim()).toBe('pkg-1@0.3.0')
+        // Now we publish. It's up to monoweave to deal with or prevent conflicts.
+        const { error: error3 } = await run()
+        if (error3) console.error(error3)
+        expect(error3).toBeUndefined()
 
-                // NOTE: the hard reset we do disassociates the git tag with the HEAD of main.
-                // This causes the change_3 monoweave run to include changes 2 and 3. This is
-                // just a quirk of the test scenario.
-            },
-        }),
-    )
+        // If we get this far, monoweave didn't fail due to the conflicts. We'll verify the changelog
+        // with ordering:
+        remoteChangelog = (await exec('git cat-file blob origin/main:packages/pkg-1/CHANGELOG.md'))
+            .stdout
+        expect(remoteChangelog).toMatch(/change 3.*change 2.*change 1/s)
+        await exec('git checkout --force change_3')
+        expect((await exec('git describe --abbrev=0')).stdout.trim()).toBe('pkg-1@0.3.0')
+
+        // NOTE: the hard reset we do disassociates the git tag with the HEAD of main.
+        // This causes the change_3 monoweave run to include changes 2 and 3. This is
+        // just a quirk of the test scenario.
+    })
 })

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
         "lint:ci": "eslint . --format junit --output-file ${ARTIFACT_DIR:-artifacts}/test_results/eslint/eslint.junit.xml",
         "lint:fix": "eslint . --fix",
         "lint": "eslint .",
+        "bin:jest:debug": "yarn node --inspect-brk --experimental-vm-modules $(yarn bin jest) --config=jest.config.js",
         "bin:jest": "yarn node --experimental-vm-modules $(yarn bin jest) --config=jest.config.js",
         "test:ci": "CI=1 yarn bin:jest --ci --runInBand --selectProjects \"Unit/Integration\" --",
         "test:watch": "yarn bin:jest --watch --selectProjects \"Unit/Integration\" --",

--- a/packages/git/src/gitCommands.ts
+++ b/packages/git/src/gitCommands.ts
@@ -81,7 +81,7 @@ export const gitDiffTree = async (
         await git('fetch', { cwd, context })
     }
 
-    const args: string[] = ['--no-commit-id', '--name-only', '-r', '--root']
+    const args: string[] = ['--no-commit-id', '--name-only', '-r', '--root', '--relative']
     if (onlyIncludeDeletedFiles) {
         args.push('--diff-filter=D')
     }

--- a/testUtils/fs.ts
+++ b/testUtils/fs.ts
@@ -10,11 +10,12 @@ export async function createFile({
     filePath: string
     content?: string
     cwd: string
-}): Promise<void> {
-    const parent = path.dirname(filePath)
+}): Promise<string> {
     const fileContent = content ?? 'some content'
-    await fs.mkdir(`${cwd}/${parent}`, { recursive: true })
-    await fs.writeFile(`${cwd}/${filePath}`, fileContent)
+    const fullpath = path.join(cwd, filePath)
+    await fs.mkdir(path.dirname(fullpath), { recursive: true })
+    await fs.writeFile(fullpath, fileContent)
+    return fullpath
 }
 
 export async function createTempDir(): Promise<{ dir: string } & AsyncDisposable> {


### PR DESCRIPTION
## Description

<!-- Provide a description of what your PR introduces or changes. -->

See #165.

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Closes #165
## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] I agree to abide by the [Code of Conduct](https://github.com/monoweave/monoweave/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the relevant gatsby files (documentation).
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
