### PR TITLE
Fix ESM config imports on Windows

### DIFF
--- a/packages/cli/src/command/config/readConfigFile.ts
+++ b/packages/cli/src/command/config/readConfigFile.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 import type { MonoweaveConfigFile } from '@monoweave/types'
 import { structUtils } from '@yarnpkg/core'
@@ -32,7 +33,8 @@ async function loadFile(filename: string): Promise<unknown> {
     return require(filename)
   }
 
-  const mod = await import(filename)
+  const importPath = path.isAbsolute(filename) ? pathToFileURL(filename).href : filename
+  const mod = await import(importPath)
   if ('default' in mod && mod.default) {
     return mod.default
   }


### PR DESCRIPTION
## Summary

- Convert absolute ESM config file paths to `file://` URLs before dynamic import
- Keep package/preset imports unchanged

Fixes #213

## Testing

- `git diff --check`
- Not run: targeted Vitest command, because this environment does not have Yarn or Corepack available