### PR TITLE
fix(plugin-github): send make_latest as string per GitHub REST API

### DIFF
--- a/packages/plugin-github/src/__tests__/plugin.test.ts
+++ b/packages/plugin-github/src/__tests__/plugin.test.ts
@@ -214,7 +214,7 @@ describe('GitHub Plugin', () => {
         repo: 'repo',
         tag_name: 'pkg-1@1.0.0',
         prerelease: false,
-        make_latest: true,
+        make_latest: 'true',
         body: 'Implicit version bump due to dependency updates.',
       }),
     )
@@ -286,7 +286,7 @@ describe('GitHub Plugin', () => {
         repo: 'repo',
         tag_name: 'pkg-1@1.0.0',
         prerelease: false,
-        make_latest: true,
+        make_latest: 'true',
         body: 'a new feature',
       }),
     )
@@ -326,7 +326,7 @@ describe('GitHub Plugin', () => {
       expect.anything(),
       expect.any(String),
       expect.objectContaining({
-        make_latest: false,
+        make_latest: 'false',
       }),
     )
   })

--- a/packages/plugin-github/src/plugin.ts
+++ b/packages/plugin-github/src/plugin.ts
@@ -133,7 +133,10 @@ export const createPluginInternals =
           body: combinedChangelog,
           draft: false,
           prerelease: config.prerelease,
-          make_latest: options.makeLatest ?? true,
+          // The GitHub REST API expects make_latest as a string enum
+          // ('true' | 'false' | 'legacy'), not a boolean.
+          // See: https://docs.github.com/en/rest/releases/releases#create-a-release
+          make_latest: (options.makeLatest ?? true) ? 'true' : 'false',
         })
       }
     }


### PR DESCRIPTION
## Summary

`@monoweave/plugin-github` fails to create GitHub releases because it sends `make_latest` as a **boolean** to the "Create a release" REST API, which requires a **string enum**.

## Symptom

Every release that reaches the GitHub release hook fails with HTTP 422:

```
HttpError: Invalid request. For 'properties/make_latest', true is not a string.
```

## Root cause

In `packages/plugin-github/src/plugin.ts` the release request passed:

```ts
make_latest: options.makeLatest ?? true,
```

GitHub's [Create a release](https://docs.github.com/en/rest/releases/releases?apiVersion=2026-03-10#create-a-release) endpoint defines `make_latest` as type `string` with the enum `"true" | "false" | "legacy"` (default `"true"`). Passing a JS boolean is now rejected.

## Fix

Convert the boolean option to the corresponding string literal at the call site:

```ts
make_latest: (options.makeLatest ?? true) ? 'true' : 'false',
```

This produces the literal type `'true' | 'false'`, which satisfies octokit's expected string enum (verified by `yarn typecheck`). The public `makeLatest?: boolean` option type is intentionally **unchanged**, so this is not a breaking change for consumers.

Existing tests in `packages/plugin-github/src/__tests__/plugin.test.ts` were updated to assert the string values (`'true'` / `'false'`).

## Impact

This affects all current versions, including the latest **3.8.0** — the release hook is broken for every release until this lands. A `patch` bump to `@monoweave/plugin-github` is appropriate (handled automatically via the conventional-commit `fix(plugin-github): ...` message).

## Verification

- `yarn typecheck` — passes (confirms the string literal satisfies octokit's `make_latest` union)
- `yarn test` — full unit/integration suite passes (281 passed, 2 todo), including the updated plugin assertions
- `oxfmt --check` / `oxlint` — pass on the touched files
