### PR TITLE
fix: don't overwrite bare workspace versions on disk

### DIFF
--- a/packages/io/src/__tests__/patchPackageJsons.test.ts
+++ b/packages/io/src/__tests__/patchPackageJsons.test.ts
@@ -60,9 +60,8 @@ describe('Patch Package Manifests', () => {
     expect(manifest3.version).toBe('3.0.0')
 
     expect(manifest1.dependencies.get(manifest2.name!.identHash)!.range).toBe('workspace:^2.0.0')
-    expect(manifest1.peerDependencies.get(manifest3.name!.identHash)!.range).toBe(
-      'workspace:^3.0.0',
-    )
+    // peer deps default to workspace:* and bare aliases are preserved on disk
+    expect(manifest1.peerDependencies.get(manifest3.name!.identHash)!.range).toBe('workspace:*')
     expect(manifest2.dependencies.get(manifest3.name!.identHash)!.range).toBe('workspace:^3.0.0')
   })
 
@@ -237,16 +236,18 @@ describe('Patch Package Manifests', () => {
     expect(manifest1.dependencies.get(manifest2.name!.identHash)!.range).toBe('workspace:^2.0.0')
   })
 
-  it('preserves bare workspace:^ and workspace:~ aliases on disk', async () => {
+  it('preserves bare workspace:^, workspace:~, and workspace:* aliases on disk', async () => {
     await using context = await createMonorepoContext({
       'pkg-1': {
         dependencies: [
           ['pkg-2', 'workspace:^'],
           ['pkg-3', 'workspace:~'],
+          ['pkg-4', 'workspace:*'],
         ],
       },
       'pkg-2': {},
       'pkg-3': {},
+      'pkg-4': {},
     })
     const config = {
       ...(await getMonoweaveConfig({
@@ -260,15 +261,17 @@ describe('Patch Package Manifests', () => {
     const workspace1 = identToWorkspace(context, 'pkg-1')
     const workspace2 = identToWorkspace(context, 'pkg-2')
     const workspace3 = identToWorkspace(context, 'pkg-3')
+    const workspace4 = identToWorkspace(context, 'pkg-4')
 
     await patchPackageJsons({
       config,
       context,
-      workspaces: new Set([workspace1, workspace2, workspace3]),
+      workspaces: new Set([workspace1, workspace2, workspace3, workspace4]),
       registryTags: new Map([
         ['pkg-1', '1.0.0'],
         ['pkg-2', '0.3.1'],
         ['pkg-3', '0.3.1'],
+        ['pkg-4', '0.3.1'],
       ]),
     })
 
@@ -279,13 +282,18 @@ describe('Patch Package Manifests', () => {
     expect(workspace1.manifest.dependencies.get(workspace3.manifest.name!.identHash)!.range).toBe(
       '^0.3.1',
     )
+    expect(workspace1.manifest.dependencies.get(workspace4.manifest.name!.identHash)!.range).toBe(
+      '^0.3.1',
+    )
 
     // Persist path: bare aliases must stay unpinned so yarn.lock descriptors stay stable
     const manifest1 = await loadManifest(context, 'pkg-1')
     const manifest2 = await loadManifest(context, 'pkg-2')
     const manifest3 = await loadManifest(context, 'pkg-3')
+    const manifest4 = await loadManifest(context, 'pkg-4')
     expect(manifest1.dependencies.get(manifest2.name!.identHash)!.range).toBe('workspace:^')
     expect(manifest1.dependencies.get(manifest3.name!.identHash)!.range).toBe('workspace:~')
+    expect(manifest1.dependencies.get(manifest4.name!.identHash)!.range).toBe('workspace:*')
   })
 
   it('does not modify disk in dry run mode', async () => {
@@ -386,9 +394,12 @@ describe('Patch Package Manifests', () => {
         const manifest3 = await loadManifest(context, 'pkg-3')
 
         expect(manifest3.version).toBe(fromVersion)
-        expect(manifest1.peerDependencies.get(manifest3.name!.identHash)!.range).toBe(
-          `workspace:^${expectedVersion}`,
-        )
+        // Publish path: in-memory peer deps get the coerced concrete range
+        expect(
+          workspace1.manifest.peerDependencies.get(workspace3.manifest.name!.identHash)!.range,
+        ).toBe(`^${expectedVersion}`)
+        // Persist path: bare workspace:* alias stays unpinned on disk
+        expect(manifest1.peerDependencies.get(manifest3.name!.identHash)!.range).toBe('workspace:*')
       },
     )
   })

--- a/packages/io/src/__tests__/patchPackageJsons.test.ts
+++ b/packages/io/src/__tests__/patchPackageJsons.test.ts
@@ -237,6 +237,57 @@ describe('Patch Package Manifests', () => {
     expect(manifest1.dependencies.get(manifest2.name!.identHash)!.range).toBe('workspace:^2.0.0')
   })
 
+  it('preserves bare workspace:^ and workspace:~ aliases on disk', async () => {
+    await using context = await createMonorepoContext({
+      'pkg-1': {
+        dependencies: [
+          ['pkg-2', 'workspace:^'],
+          ['pkg-3', 'workspace:~'],
+        ],
+      },
+      'pkg-2': {},
+      'pkg-3': {},
+    })
+    const config = {
+      ...(await getMonoweaveConfig({
+        cwd: context.project.cwd,
+        baseBranch: 'main',
+        commitSha: 'shashasha',
+      })),
+      persistVersions: true,
+    }
+
+    const workspace1 = identToWorkspace(context, 'pkg-1')
+    const workspace2 = identToWorkspace(context, 'pkg-2')
+    const workspace3 = identToWorkspace(context, 'pkg-3')
+
+    await patchPackageJsons({
+      config,
+      context,
+      workspaces: new Set([workspace1, workspace2, workspace3]),
+      registryTags: new Map([
+        ['pkg-1', '1.0.0'],
+        ['pkg-2', '0.3.1'],
+        ['pkg-3', '0.3.1'],
+      ]),
+    })
+
+    // Publish path: in-memory manifests still get concrete semver ranges
+    expect(workspace1.manifest.dependencies.get(workspace2.manifest.name!.identHash)!.range).toBe(
+      '^0.3.1',
+    )
+    expect(workspace1.manifest.dependencies.get(workspace3.manifest.name!.identHash)!.range).toBe(
+      '^0.3.1',
+    )
+
+    // Persist path: bare aliases must stay unpinned so yarn.lock descriptors stay stable
+    const manifest1 = await loadManifest(context, 'pkg-1')
+    const manifest2 = await loadManifest(context, 'pkg-2')
+    const manifest3 = await loadManifest(context, 'pkg-3')
+    expect(manifest1.dependencies.get(manifest2.name!.identHash)!.range).toBe('workspace:^')
+    expect(manifest1.dependencies.get(manifest3.name!.identHash)!.range).toBe('workspace:~')
+  })
+
   it('does not modify disk in dry run mode', async () => {
     await using context = await createMonorepoContext({
       'pkg-1': {

--- a/packages/io/src/patchPackageJsons.ts
+++ b/packages/io/src/patchPackageJsons.ts
@@ -65,10 +65,17 @@ const patchPackageJsons = async ({
         const dependencyIdent = structUtils.convertToIdent(descriptor)
 
         // If dependency is using "workspace:" protocol, preserve it when
-        // persisting manifest
+        // persisting manifest. Bare caret/tilde aliases must stay unpinned so
+        // yarn.lock descriptors remain stable across releases. workspace:* is
+        // still rewritten to a concrete caret range (existing publish behavior).
         if (descriptor.range.startsWith('workspace:')) {
+          const isBareAlias =
+            descriptor.range === 'workspace:^' || descriptor.range === 'workspace:~'
           workspaceProtocols[dependentSetKey].push(
-            structUtils.makeDescriptor(dependencyIdent, `workspace:^${dependencyVersion}`),
+            structUtils.makeDescriptor(
+              dependencyIdent,
+              isBareAlias ? descriptor.range : `workspace:^${dependencyVersion}`,
+            ),
           )
         }
 

--- a/packages/io/src/patchPackageJsons.ts
+++ b/packages/io/src/patchPackageJsons.ts
@@ -65,12 +65,11 @@ const patchPackageJsons = async ({
         const dependencyIdent = structUtils.convertToIdent(descriptor)
 
         // If dependency is using "workspace:" protocol, preserve it when
-        // persisting manifest. Bare caret/tilde aliases must stay unpinned so
-        // yarn.lock descriptors remain stable across releases. workspace:* is
-        // still rewritten to a concrete caret range (existing publish behavior).
+        // persisting manifest.
+        // Bare aliases (workspace:^, workspace:~, workspace:*) must stay
+        // unpinned so yarn.lock descriptors remain stable across releases.
         if (descriptor.range.startsWith('workspace:')) {
-          const isBareAlias =
-            descriptor.range === 'workspace:^' || descriptor.range === 'workspace:~'
+          const isBareAlias = /^workspace:[*^~]$/.test(descriptor.range)
           workspaceProtocols[dependentSetKey].push(
             structUtils.makeDescriptor(
               dependencyIdent,


### PR DESCRIPTION
## Description

We're seeing yarn.lock get out of date when we use bare dependencies on other packages. This should not affect the published version, but keep the version on disk correct.

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Closes #0, a short description of the linked issue.

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [ ] I agree to abide by the [Code of Conduct](https://github.com/monoweave/monoweave/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the relevant doc-site files (documentation).
- [ ] This PR has sufficient test coverage.
- [ ] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
